### PR TITLE
HttpErrorCode's type was set to 'int'. Because HttpStatsCode type may be used in another module

### DIFF
--- a/Decisions.GoogleDrive/Data/GoogleDriveResult.cs
+++ b/Decisions.GoogleDrive/Data/GoogleDriveResult.cs
@@ -4,19 +4,17 @@ using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace Decisions.GoogleDrive
 {
-
     [DataContract]
     public class GoogleDriveErrorInfo
     {
         [DataMember] public string ErrorMessage { get; set; }
-        [DataMember] public HttpStatusCode? HttpErrorCode { get; set; }
+        [DataMember] public int? HttpErrorCode { get; set; }
     }
 
     public class GoogleDriveBaseResult
@@ -34,14 +32,15 @@ namespace Decisions.GoogleDrive
             {
                 var ex = (Google.GoogleApiException)exception;
                 ErrorInfo.ErrorMessage = ex.Error?.Message ?? (ex.Message ?? ex.ToString());
-                ErrorInfo.HttpErrorCode = ex.HttpStatusCode;
+                ErrorInfo.HttpErrorCode = (int)ex.HttpStatusCode;
                 return true;
             }
             else if (exception is Google.Apis.Auth.OAuth2.Responses.TokenResponseException)
             {
                 var ex = (Google.Apis.Auth.OAuth2.Responses.TokenResponseException)exception;
                 ErrorInfo.ErrorMessage = ex.Error?.ToString() ?? (ex.Message ?? ex.ToString());
-                ErrorInfo.HttpErrorCode = ex.StatusCode;
+                if(ex.StatusCode!=null)
+                    ErrorInfo.HttpErrorCode = (int)ex.StatusCode;
                 return true;
             }
 

--- a/Decisions.GoogleDrive/Utility/GoogleDriveUtility.cs
+++ b/Decisions.GoogleDrive/Utility/GoogleDriveUtility.cs
@@ -190,7 +190,7 @@ namespace Decisions.GoogleDrive
                     res.Data = GoogleDriveResourceType.File;
             });
 
-            if (result.ErrorInfo.HttpErrorCode == HttpStatusCode.NotFound)
+            if (result.ErrorInfo.HttpErrorCode == (int)HttpStatusCode.NotFound)
             {
                 result.IsSucceed = true;
                 result.Data = GoogleDriveResourceType.Unavailable;


### PR DESCRIPTION
Decisions have an error, when Decisions.Jira and Decisions.GoogleDrive both are installed
![image](https://user-images.githubusercontent.com/7510942/92618903-83b13b00-f2c9-11ea-80be-030cee9a5a5f.png)
